### PR TITLE
Image 컴포넌트 추가

### DIFF
--- a/src/components/atoms/Image/Image.stories.tsx
+++ b/src/components/atoms/Image/Image.stories.tsx
@@ -1,0 +1,30 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import Image from "./Image";
+
+const meta = {
+  title: "Atom/Image",
+  component: Image,
+  parameters: {
+    layout: "centered",
+  },
+  tags: ["autodocs"],
+  argTypes: {
+    rounded: {
+      options: ["none", "xs", "s", "m", "l", "circle"],
+      control: { type: "radio" },
+    },
+  },
+  args: {
+    className: "h-[160rem]",
+    src: "https://img1.daumcdn.net/thumb/R1280x0/?scode=mtistory2&fname=https%3A%2F%2Fblog.kakaocdn.net%2Fdn%2FbixMVD%2FbtsnzFZlqlV%2FJiuZ2EpykdTd37Kljphibk%2Fimg.png",
+    alt: "react component",
+  },
+} satisfies Meta<typeof Image>;
+
+export default meta;
+type Story = StoryObj<typeof Image>;
+
+export const Default: Story = {
+  render: (args) => <Image {...args} />,
+};

--- a/src/components/atoms/Image/Image.tsx
+++ b/src/components/atoms/Image/Image.tsx
@@ -1,0 +1,47 @@
+import { VariantProps, cva, cx } from "class-variance-authority";
+import * as NextImage from "next/image";
+
+const ImageVariants = cva("relative overflow-hidden aspect-square", {
+  variants: {
+    rounded: {
+      none: "rounded-none",
+      xs: "rounded-xs",
+      s: "rounded-s",
+      m: "rounded-m",
+      l: "rounded-l",
+      circle: "rounded-circle",
+    },
+  },
+  defaultVariants: {
+    rounded: "m",
+  },
+});
+
+type ImagePropsType = Omit<
+  NextImage.ImageProps,
+  | "width"
+  | "height"
+  | "fill"
+  //이하 deprecated props
+  | "layout"
+  | "objectFit"
+  | "objectPosition"
+  | "lazyBoundary"
+  | "lazyRoot"
+> &
+  VariantProps<typeof ImageVariants>;
+
+const Image = ({ className, rounded, alt, ...props }: ImagePropsType) => {
+  return (
+    <div className={cx(className, ImageVariants({ rounded }))}>
+      <NextImage.default
+        fill={true}
+        alt={alt}
+        style={{ objectFit: "cover" }}
+        {...props}
+      />
+    </div>
+  );
+};
+
+export default Image;


### PR DESCRIPTION
## PR 종류

어떤 타입의 Pull Request인가요?

- [ ] 버그 픽스
- [X] 기능 추가
- [ ] CSS 변경
- [ ] 코드 스타일 변경(포맷팅, 지역 변수 등)
- [ ] 리팩토링(기능 변경 X, API 변경 X)
- [ ] 환경 설정 관련 변경
- [ ] 문서 수정
- [ ] 기타... : 설명해주세요.

## 현재는 어떻게 동작하나요?

이미지 태그를 위한 별도의 컴포넌트가 존재하지 않습니다.
next/image로 Image 태그를 불러와 className을 넣어 사용합니다.

이슈 번호: #16 

## PR이 적용된다면 어떻게 동작하나요?

Image 컴포넌트를 통해 Image를 렌더링할 수 있습니다.

## 기타 정보

![image](https://github.com/bh2980/chistock/assets/74360958/f37154dd-32b6-4a6e-b008-0c2ce385ff29)


width, height 조정을 위해 className을 허용했습니다.
기본적으로 aspect-square로 설정되어, width나 height 둘 중 하나만 설정해도 작동합니다.
next/image에서 필수였던 width, height를 삭제하고 className을 통해 div에서 간접적으로 설정할 수 있도록 변경했습니다.
기존 next/image의 props 중 deprecated된 props들을 Image 컴포넌트에서 제외했습니다.
