### PR TITLE
As 제한 다형성 컴포넌트 적용

### DIFF
--- a/src/components/atoms/Box/Box.tsx
+++ b/src/components/atoms/Box/Box.tsx
@@ -1,10 +1,22 @@
 import { PolymorphicPropsWithInnerRefType } from "@customTypes/polymorphicType";
 
-/** Box를 반환하는 함수입니다.
+/** renderAs의 기본값이 지정된 Box를 반환하는 함수입니다.
  *
- * T를 제공해 특정 타입의 박스를 반환하게 할 수 있습니다.
+ * renderAs의 종류를 제한할 때에는 가능한 타입을 Union으로 결합하여 제네릭으로 넣어주세요.
+ *
+ * @param `defaultAs` : 기본적으로 렌더링 될 태그 혹은 컴포넌트 타입
+ *
+ * @example
+ * // 기본적으로 `button`태그로 렌더링되면서
+ * //`button`, `a` 태그만 렌더링로만 가능한 Box 컴포넌트
+ * createBox<'button' | 'a'>('button')
  */
-export const createBox = <T extends React.ElementType>() => Box<T>;
+export const createBox = <T extends React.ElementType>(defaultAs: T) => {
+  // eslint-disable-next-line react/display-name
+  return ({ renderAs = defaultAs, ...rest }: PolymorphicPropsWithInnerRefType<T>) => {
+    return <Box renderAs={renderAs} {...(rest as PolymorphicPropsWithInnerRefType<T>)} />;
+  };
+};
 
 /**
  * 무엇이든 될 수 있는 기본 다형성 컴포넌트입니다.

--- a/src/components/atoms/Box/Box.tsx
+++ b/src/components/atoms/Box/Box.tsx
@@ -1,4 +1,4 @@
-import { PolymorphicPropsType } from "@customTypes/polymorphicType";
+import { PolymorphicPropsWithInnerRefType } from "@customTypes/polymorphicType";
 
 /** Box를 반환하는 함수입니다.
  *
@@ -13,11 +13,12 @@ export const createBox = <T extends React.ElementType>() => Box<T>;
  */
 const Box = <T extends React.ElementType = "div">({
   renderAs,
+  innerRef,
   ...props
-}: PolymorphicPropsType<T>) => {
+}: PolymorphicPropsWithInnerRefType<T>) => {
   const Root = renderAs || "div";
 
-  return <Root {...props}></Root>;
+  return <Root ref={innerRef} {...props}></Root>;
 };
 
 export default Box;

--- a/src/components/atoms/Button/Button.tsx
+++ b/src/components/atoms/Button/Button.tsx
@@ -1,40 +1,27 @@
-import React, { PropsWithChildren } from "react";
-import { VariantProps, cva } from "class-variance-authority";
-
-import classMerge from "@utils/classMerge";
+import { cva } from "class-variance-authority";
 import { twJoin } from "tailwind-merge";
 
-import { PolymorphicPropsTypeWithInnerRef } from "@customTypes/polymorphicType";
-import { NonNullableProps } from "@customTypes/utilType";
+import { PolymorphicPropsWithInnerRefType } from "@customTypes/polymorphicType";
 
-export type ButtonPropsType = NonNullableProps<
-  VariantProps<typeof buttonVariants>
-> & {
-  /** disabled props 설명
-   * @default false
-   */
-  disabled?: boolean;
-  icon?: React.ReactElement;
-  iconPosition?: "before" | "after";
-};
+import classMerge from "@utils/classMerge";
+
+import { createBox } from "@atoms/Box/Box";
+
+import { AlternateAs, ButtonBaseType, DefaultType, IconWrapperPropsType } from "./Button.types";
 
 export const has = (item: unknown) => !!item;
 
-type IconWrapperPropsType = PropsWithChildren &
-  Pick<ButtonPropsType, "iconPosition"> & {
-    isIconButton?: boolean;
-  };
-
-const buttonVariants = cva(
+export const buttonVariants = cva(
   "relative flex justify-center items-center overflow-hidden rounded-m py-xs",
   {
     variants: {
+      /** vatiants 설명 */
       variant: {
         primary: "bg-primary text-primary-on",
         secondary: "bg-secondary text-secondary-on",
         danger: "bg-red text-red-on",
         text: "text-surface-on-variant",
-      },
+      } /** size 설명 */,
       size: {
         s: "h-[32rem] px-s text-s",
         m: "h-[40rem] px-m text-m",
@@ -48,23 +35,20 @@ const buttonVariants = cva(
   }
 );
 
-const buttonDisabledVariants = cva(
-  "text-surface-on/30 grayscale pointer-events-none",
-  {
-    variants: {
-      /** variant props 설명 */
-      variant: {
-        primary: "bg-surface-on/10",
-        secondary: "bg-surface-on/10",
-        danger: "bg-surface-on/10",
-        text: "bg-transparent",
-      },
+const buttonDisabledVariants = cva("text-surface-on/30 grayscale pointer-events-none", {
+  variants: {
+    /** variant props 설명 */
+    variant: {
+      primary: "bg-surface-on/10",
+      secondary: "bg-surface-on/10",
+      danger: "bg-surface-on/10",
+      text: "bg-transparent",
     },
-    defaultVariants: {
-      variant: "secondary",
-    },
-  }
-);
+  },
+  defaultVariants: {
+    variant: "secondary",
+  },
+});
 
 const iconButtonPadding = cva("aspect-square", {
   variants: {
@@ -82,11 +66,7 @@ const Overlay = () => {
   );
 };
 
-const IconWrapper = ({
-  iconPosition,
-  isIconButton,
-  children,
-}: IconWrapperPropsType) => {
+const IconWrapper = ({ iconPosition, isIconButton, children }: IconWrapperPropsType) => {
   return (
     <span
       className={twJoin(
@@ -102,7 +82,11 @@ const IconWrapper = ({
 /**
  * Button 컴포넌트
  */
-const Button = <T extends React.ElementType = "button">({
+
+const Button = <
+  T extends DefaultType | AlternateAs = DefaultType,
+  A extends AlternateAs = AlternateAs
+>({
   children,
   renderAs,
   className,
@@ -110,17 +94,16 @@ const Button = <T extends React.ElementType = "button">({
   size,
   icon,
   iconPosition = "before",
-  innerRef,
   disabled,
   ...props
-}: PolymorphicPropsTypeWithInnerRef<T, ButtonPropsType>) => {
-  const Root = renderAs || "button";
-
+}: PolymorphicPropsWithInnerRefType<T, ButtonBaseType, A>) => {
   const isIconButton = has(icon) && !has(children);
+
+  const Root = createBox<DefaultType | AlternateAs>();
 
   return (
     <Root
-      ref={innerRef}
+      renderAs={renderAs || "button"}
       className={classMerge(
         twJoin([
           buttonVariants({ variant, size }),

--- a/src/components/atoms/Button/Button.tsx
+++ b/src/components/atoms/Button/Button.tsx
@@ -7,7 +7,12 @@ import classMerge from "@utils/classMerge";
 
 import { createBox } from "@atoms/Box/Box";
 
-import { AlternateAs, ButtonBaseType, DefaultType, IconWrapperPropsType } from "./Button.types";
+import {
+  ButtonAlterAs,
+  ButtonBasePropsType,
+  ButtonDefault,
+  IconWrapperPropsType,
+} from "./Button.types";
 
 export const has = (item: unknown) => !!item;
 
@@ -84,8 +89,8 @@ const IconWrapper = ({ iconPosition, isIconButton, children }: IconWrapperPropsT
  */
 
 const Button = <
-  T extends DefaultType | AlternateAs = DefaultType,
-  A extends AlternateAs = AlternateAs
+  T extends ButtonDefault | ButtonAlterAs = ButtonDefault,
+  A extends ButtonAlterAs = ButtonAlterAs
 >({
   children,
   renderAs,
@@ -96,10 +101,10 @@ const Button = <
   iconPosition = "before",
   disabled,
   ...props
-}: PolymorphicPropsWithInnerRefType<T, ButtonBaseType, A>) => {
+}: PolymorphicPropsWithInnerRefType<T, ButtonBasePropsType, A>) => {
   const isIconButton = has(icon) && !has(children);
 
-  const Root = createBox<DefaultType | AlternateAs>();
+  const Root = createBox<ButtonDefault | ButtonAlterAs>();
 
   return (
     <Root

--- a/src/components/atoms/Button/Button.tsx
+++ b/src/components/atoms/Button/Button.tsx
@@ -104,11 +104,11 @@ const Button = <
 }: PolymorphicPropsWithInnerRefType<T, ButtonBasePropsType, A>) => {
   const isIconButton = has(icon) && !has(children);
 
-  const Root = createBox<ButtonDefault | ButtonAlterAs>();
+  const ButtonRoot = createBox<ButtonDefault | ButtonAlterAs>("button");
 
   return (
-    <Root
-      renderAs={renderAs || "button"}
+    <ButtonRoot
+      renderAs={renderAs}
       className={classMerge(
         twJoin([
           buttonVariants({ variant, size }),
@@ -131,7 +131,7 @@ const Button = <
         </IconWrapper>
       )}
       <Overlay />
-    </Root>
+    </ButtonRoot>
   );
 };
 

--- a/src/components/atoms/Button/Button.types.ts
+++ b/src/components/atoms/Button/Button.types.ts
@@ -5,10 +5,13 @@ import { NonNullableProps } from "@customTypes/utilType";
 
 import { buttonVariants } from "./Button";
 
-export type DefaultType = "button";
-export type AlternateAs = "a" | typeof Link;
+/** Button 컴포넌트 기본 타입 */
+export type ButtonDefault = "button";
 
-export type ButtonBaseType = NonNullableProps<VariantProps<typeof buttonVariants>> & {
+/** Button 컴포넌트가 렌더링될 수 있는 다른 타입 */
+export type ButtonAlterAs = "a" | typeof Link;
+
+export type ButtonBasePropsType = NonNullableProps<VariantProps<typeof buttonVariants>> & {
   /** disabled props 설명
    * @default false
    */

--- a/src/components/atoms/Button/Button.types.ts
+++ b/src/components/atoms/Button/Button.types.ts
@@ -1,0 +1,25 @@
+import { VariantProps } from "class-variance-authority";
+import Link from "next/link";
+
+import { NonNullableProps } from "@customTypes/utilType";
+
+import { buttonVariants } from "./Button";
+
+export type DefaultType = "button";
+export type AlternateAs = "a" | typeof Link;
+
+export type ButtonBaseType = NonNullableProps<VariantProps<typeof buttonVariants>> & {
+  /** disabled props 설명
+   * @default false
+   */
+  disabled?: boolean;
+  /** Icon 컴포넌트 타입 */
+  icon?: React.ReactElement;
+  /** 아이콘 위치 */
+  iconPosition?: "before" | "after";
+};
+
+export type IconWrapperPropsType = React.PropsWithChildren & {
+  isIconButton?: boolean;
+  iconPosition?: "before" | "after";
+};

--- a/src/components/atoms/Text/Text.tsx
+++ b/src/components/atoms/Text/Text.tsx
@@ -44,11 +44,11 @@ const Text = <
   weight,
   ...props
 }: PolymorphicPropsWithInnerRefType<T, TextBasePropsType, A>) => {
-  const TextRoot = createBox<TextDefault | TextAlterAs>();
+  const TextRoot = createBox<TextDefault | TextAlterAs>("span");
 
   return (
     <TextRoot
-      renderAs={renderAs || "span"}
+      renderAs={renderAs}
       className={classMerge([
         textVariants({ size, weight }),
         textColorVariants({ color }),

--- a/src/components/atoms/Text/Text.tsx
+++ b/src/components/atoms/Text/Text.tsx
@@ -1,26 +1,17 @@
-import { VariantProps, cva } from "class-variance-authority";
+import { cva } from "class-variance-authority";
+
+import { PolymorphicPropsWithInnerRefType } from "@customTypes/polymorphicType";
+
+import { textColorVariants } from "@constants/textColor";
 
 import classMerge from "@utils/classMerge";
-import { PolymorphicPropsTypeWithInnerRef } from "@customTypes/polymorphicType";
 
-type TextPropsType = VariantProps<typeof textVariants>;
+import { createBox } from "@atoms/Box/Box";
+
+import { TextAlterAs, TextBasePropsType, TextDefault } from "./Text.types";
 
 export const textVariants = cva("", {
   variants: {
-    color: {
-      current: "text-current",
-      onSurface: "text-surface-on",
-      onSub: "text-surface-on-variant",
-      onPrimary: "text-primary-on",
-      onPrimaryFixed: "text-primary-fixed-on",
-      onSecondary: "text-secondary-on",
-      onSecondaryFixed: "text-secondary-fixed-on",
-      onTertiary: "text-tertiary-on",
-      onTertiaryFixed: "text-tertiary-fixed-on",
-      onRed: "text-red-on",
-      onRedSub: "text-red-variant-on",
-      onYellow: "text-yellow-on",
-    },
     size: {
       inherit: "text-inherit",
       xs: "text-xs",
@@ -36,32 +27,37 @@ export const textVariants = cva("", {
     },
   },
   defaultVariants: {
-    color: "current",
     size: "inherit",
     weight: "regular",
   },
 });
 
-const Text = <T extends React.ElementType>({
+const Text = <
+  T extends TextDefault | TextAlterAs = TextDefault,
+  A extends TextAlterAs = TextAlterAs
+>({
   children,
   renderAs,
   className,
   color,
   size,
   weight,
-  innerRef,
   ...props
-}: PolymorphicPropsTypeWithInnerRef<T, TextPropsType>) => {
-  const TextComponent = renderAs || "span";
+}: PolymorphicPropsWithInnerRefType<T, TextBasePropsType, A>) => {
+  const TextRoot = createBox<TextDefault | TextAlterAs>();
 
   return (
-    <TextComponent
-      ref={innerRef}
-      className={classMerge([textVariants({ color, size, weight }), className])}
+    <TextRoot
+      renderAs={renderAs || "span"}
+      className={classMerge([
+        textVariants({ size, weight }),
+        textColorVariants({ color }),
+        className,
+      ])}
       {...props}
     >
       {children}
-    </TextComponent>
+    </TextRoot>
   );
 };
 

--- a/src/components/atoms/Text/Text.types.ts
+++ b/src/components/atoms/Text/Text.types.ts
@@ -1,4 +1,5 @@
 import { VariantProps } from "class-variance-authority";
+import Link from "next/link";
 
 import { NonNullableProps } from "@customTypes/utilType";
 
@@ -14,7 +15,7 @@ export type TextDefault = "span";
  *
  * 필요 시 추가 후 사용
  */
-export type TextAlterAs = "div" | "a" | "p" | "h1" | "h2" | "h3" | "h4" | "h5" | "h6";
+export type TextAlterAs = "div" | "a" | "p" | "h1" | "h2" | "h3" | "h4" | "h5" | "h6" | typeof Link;
 
 /**
  * Text 컴포넌트 기본 Props 타입

--- a/src/components/atoms/Text/Text.types.ts
+++ b/src/components/atoms/Text/Text.types.ts
@@ -1,0 +1,26 @@
+import { VariantProps } from "class-variance-authority";
+
+import { NonNullableProps } from "@customTypes/utilType";
+
+import { textColorVariants } from "@constants/textColor";
+
+import { textVariants } from "./Text";
+
+/** 기본 Text 컴포넌트 타입 */
+export type TextDefault = "span";
+
+/**
+ * Text 컴포넌트가 렌더링 될 수 있는 타입
+ *
+ * 필요 시 추가 후 사용
+ */
+export type TextAlterAs = "div" | "a" | "p" | "h1" | "h2" | "h3" | "h4" | "h5" | "h6";
+
+/**
+ * Text 컴포넌트 기본 Props 타입
+ *
+ * 태그와 관련 없는 Text 컴포넌트가 가지는 고유 속성들
+ */
+export type TextBasePropsType = NonNullableProps<
+  VariantProps<typeof textColorVariants> & VariantProps<typeof textVariants>
+>;

--- a/src/components/atoms/Tile/ExpandTile.tsx
+++ b/src/components/atoms/Tile/ExpandTile.tsx
@@ -1,16 +1,21 @@
-import { useState } from "react";
 import { cva } from "class-variance-authority";
+import { useState } from "react";
 
-import { PolymorphicPropsTypeWithInnerRef } from "@customTypes/polymorphicType";
+import { PolymorphicPropsWithInnerRefType } from "@customTypes/polymorphicType";
+import { TailwindMaxHeightClassType } from "@customTypes/tailwindFormatType";
+
 import classMerge from "@utils/classMerge";
 
 import Button from "@atoms/Button/Button";
-import Tile, { TilePropsType } from "@atoms/Tile/Tile";
+import Tile from "@atoms/Tile/Tile";
 
-type ExpandTilePropsType = {
-  collapseHeight: string;
-  expandHeight: string;
-} & Omit<TilePropsType, "backgroundColor">;
+import { TileAlterAs, TileBasePropsType, TileDefault } from "./Tile.types";
+
+/** ExpandTile 기본 Props 타입 */
+export type ExpandTileBasePropsType = {
+  collapseHeight: TailwindMaxHeightClassType;
+  expandHeight: TailwindMaxHeightClassType;
+} & TileBasePropsType;
 
 const expandTileVariants = cva("", {
   variants: {
@@ -35,17 +40,19 @@ const expandTileVariants = cva("", {
 const CLOSE_TEXT = "닫기";
 const EXPAND_TEXT = "더 보기";
 
-const ExpandTile = <T extends React.ElementType>({
+const ExpandTile = <
+  T extends TileDefault | TileAlterAs = TileDefault,
+  A extends TileAlterAs = TileAlterAs
+>({
   children,
   collapseHeight,
   expandHeight = "max-h-screen",
   padding,
-  innerRef,
   ...props
-}: PolymorphicPropsTypeWithInnerRef<T, ExpandTilePropsType>) => {
+}: PolymorphicPropsWithInnerRefType<T, ExpandTileBasePropsType, A>) => {
   {
     const [isExpend, setIsExpand] = useState(false);
-    const tileProps: TilePropsType = props;
+    const { variant } = props;
 
     const changeTileState = () => {
       setIsExpand((current) => !current);
@@ -53,22 +60,20 @@ const ExpandTile = <T extends React.ElementType>({
 
     return (
       <Tile
-        ref={innerRef}
         className={classMerge([
           isExpend ? expandHeight : collapseHeight,
           "transition-[max-height]",
           expandTileVariants({ padding }),
         ])}
-        padding={"none"}
-        {...tileProps}
+        {...props}
       >
         <div className="flex flex-col w-full relative gap-s">
           <div className="h-[calc(100%-32rem)] overflow-hidden">{children}</div>
           <Button
-            variant={"text"}
+            variant={variant === undefined || variant === "default" ? "text" : variant}
             size="s"
             onClick={changeTileState}
-            className="w-full"
+            className="bg-transparent"
           >
             {isExpend ? CLOSE_TEXT : EXPAND_TEXT}
           </Button>

--- a/src/components/atoms/Tile/Tile.tsx
+++ b/src/components/atoms/Tile/Tile.tsx
@@ -66,11 +66,11 @@ const Tile = <
   shadow,
   ...props
 }: PolymorphicPropsWithInnerRefType<T, TileBasePropsType, A>) => {
-  const Root = createBox<TileDefault | TileAlterAs>();
+  const TileRoot = createBox<TileDefault | TileAlterAs>("div");
 
   return (
-    <Root
-      renderAs={renderAs || "div"}
+    <TileRoot
+      renderAs={renderAs}
       className={classMerge([
         width,
         height,
@@ -85,7 +85,7 @@ const Tile = <
       {...props}
     >
       {children}
-    </Root>
+    </TileRoot>
   );
 };
 

--- a/src/components/atoms/Tile/Tile.tsx
+++ b/src/components/atoms/Tile/Tile.tsx
@@ -10,7 +10,7 @@ import { TileAlterAs, TileBasePropsType, TileDefault } from "./Tile.types";
 
 export const tileVariants = cva("flex border border-outline-variant text-m", {
   variants: {
-    backgroundColor: {
+    variant: {
       default: "bg-surface-variant text-surface-on",
       primary: "bg-primary text-primary-on",
       secondary: "bg-secondary text-secondary-on",
@@ -21,7 +21,6 @@ export const tileVariants = cva("flex border border-outline-variant text-m", {
       s: "rounded-s",
       m: "rounded-m",
       l: "rounded-l",
-      circle: "rounded-circle",
     },
     padding: {
       none: "",
@@ -45,7 +44,7 @@ export const tileVariants = cva("flex border border-outline-variant text-m", {
     },
   },
   defaultVariants: {
-    backgroundColor: "default",
+    variant: "default",
     rounded: "m",
     padding: "2xl",
     shadow: "xs",
@@ -59,7 +58,7 @@ const Tile = <
   children,
   renderAs,
   className,
-  backgroundColor,
+  variant,
   width,
   height,
   rounded,
@@ -76,7 +75,7 @@ const Tile = <
         width,
         height,
         tileVariants({
-          backgroundColor,
+          variant,
           rounded,
           padding,
           shadow,

--- a/src/components/atoms/Tile/Tile.tsx
+++ b/src/components/atoms/Tile/Tile.tsx
@@ -1,25 +1,21 @@
-import { VariantProps, cva } from "class-variance-authority";
+import { cva } from "class-variance-authority";
 
-import { PolymorphicPropsTypeWithInnerRef } from "@customTypes/polymorphicType";
+import { PolymorphicPropsWithInnerRefType } from "@customTypes/polymorphicType";
+
 import classMerge from "@utils/classMerge";
 
-export type TilePropsType = VariantProps<typeof tileVariants>;
+import { createBox } from "@atoms/Box/Box";
 
-const tileVariants = cva("flex border border-outline-variant text-m", {
+import { TileAlterAs, TileBasePropsType, TileDefault } from "./Tile.types";
+
+export const tileVariants = cva("flex border border-outline-variant text-m", {
   variants: {
     backgroundColor: {
-      default: "bg-surface-variant",
-      primary: "bg-primary",
-      secondary: "bg-secondary",
+      default: "bg-surface-variant text-surface-on",
+      primary: "bg-primary text-primary-on",
+      secondary: "bg-secondary text-secondary-on",
     },
-    width: {
-      auto: "w-auto",
-      full: "w-full",
-      "desktop-4": "w-desktop-4",
-      "desktop-8": "w-desktop-8",
-      "desktop-12": "w-desktop-12",
-    },
-    borderRadius: {
+    rounded: {
       none: "rounded-none",
       xs: "rounded-xs",
       s: "rounded-s",
@@ -50,44 +46,47 @@ const tileVariants = cva("flex border border-outline-variant text-m", {
   },
   defaultVariants: {
     backgroundColor: "default",
-    width: "auto",
-    borderRadius: "m",
+    rounded: "m",
     padding: "2xl",
     shadow: "xs",
   },
 });
 
-const Tile = <T extends React.ElementType>({
+const Tile = <
+  T extends TileDefault | TileAlterAs = TileDefault,
+  A extends TileAlterAs = TileAlterAs
+>({
   children,
   renderAs,
   className,
   backgroundColor,
   width,
-  borderRadius,
+  height,
+  rounded,
   padding,
   shadow,
-  innerRef,
   ...props
-}: PolymorphicPropsTypeWithInnerRef<T, TilePropsType>) => {
-  const TileComponent = renderAs || "article";
+}: PolymorphicPropsWithInnerRefType<T, TileBasePropsType, A>) => {
+  const Root = createBox<TileDefault | TileAlterAs>();
 
   return (
-    <TileComponent
-      ref={innerRef}
+    <Root
+      renderAs={renderAs || "div"}
       className={classMerge([
-        className,
+        width,
+        height,
         tileVariants({
           backgroundColor,
-          width,
-          borderRadius,
+          rounded,
           padding,
           shadow,
         }),
+        className,
       ])}
       {...props}
     >
       {children}
-    </TileComponent>
+    </Root>
   );
 };
 

--- a/src/components/atoms/Tile/Tile.types.ts
+++ b/src/components/atoms/Tile/Tile.types.ts
@@ -1,0 +1,20 @@
+import { TailwindHeightClassType, TailwindWidthClassType } from "@customTypes/tailwindFormatType";
+import { VariantPropsType } from "@customTypes/utilType";
+
+import { tileVariants } from "./Tile";
+
+/** 기본 Tile 타입 */
+export type TileDefault = "div";
+
+/** Tile이 렌더링 될 수 있는 다른 타입 */
+export type TileAlterAs = "header" | "footer" | "nav" | "aside" | "main" | "section" | "article";
+
+/**
+ * Tile 컴포넌트 기본 Props 타입
+ *
+ * 태그와 관련 없는 Tile 컴포넌트 고유 속성들
+ */
+export type TileBasePropsType = {
+  width?: TailwindWidthClassType;
+  height?: TailwindHeightClassType;
+} & VariantPropsType<typeof tileVariants>;

--- a/src/customTypes/polymorphicType.ts
+++ b/src/customTypes/polymorphicType.ts
@@ -1,22 +1,64 @@
-type AsPropType<T extends React.ElementType> = {
-  renderAs?: T;
+/**
+ * 렌더링할 태그를 결정하는 renderAs 속성을 정의하는 타입
+ *
+ * @param `T` : 렌더링 될 수 있는 컴포넌트 타입
+ * @param [`A`] : 추가적으로 렌더링 될 수 있는 컴포넌트 타입 (TS 자동완성을 위해 사용)
+ *
+ * @example
+ * // { renderAs? : 'div' }
+ * AsPropsType<'div'>
+ *
+ * // { renderAs? : 'div' | 'a' | 'button' }
+ * AsPropsType<'div', 'a' | 'button'>
+ */
+type AsPropsType<T extends React.ElementType, A extends React.ElementType = T> = {
+  /** 렌더링할 태그 타입 */
+  renderAs?: T | A;
 };
 
-export type PolymorphicRefType<T extends React.ElementType> =
-  React.ComponentPropsWithRef<T>["ref"];
-
-export type InnerRefType<T extends React.ElementType> = {
-  innerRef?: PolymorphicRefType<T>;
+/**
+ * T를 받아서 T가 가지고 있는 ref 타입으로 innerRef 타입을 지정하는 타입
+ *
+ * @param `T` : 렌더링할 컴포넌트 타입
+ *
+ * @example
+ * // { innerRef?: RejObject<HTMLDivElement> | ... }
+ * InnreRefType<'div'>
+ */
+type InnerRefType<T extends React.ElementType> = {
+  /** ref를 대체하는 타입 Type */
+  innerRef?: React.ComponentPropsWithRef<T>["ref"];
 };
 
+/**
+ * 다형성 컴포넌트 Props 타입
+ *
+ * renderAs와 태그, 컴포넌트 기본 Props 추가
+ *
+ * @param `T` : Props를 사용할 컴포넌트 타입
+ * @param [`Props`] : 컴포넌트 커스텀 Props
+ * @param [`A`] : 추가적으로 렌더링 될 수 있는 컴포넌트 타입 (TS 자동완성을 위해 사용)
+ */
 export type PolymorphicPropsType<
   T extends React.ElementType,
-  Props = object
-> = AsPropType<T> &
+  Props = object,
+  AlternateAs extends React.ElementType = T
+> = AsPropsType<T, AlternateAs> & Props & Omit<React.ComponentPropsWithoutRef<T>, keyof Props>;
+
+/**
+ * 다형성 컴포넌트 Props 타입에 innerRef 속성을 추가한 타입
+ *
+ * renderAs, innerRef와 태그, 컴포넌트 기본 Props 추가
+ *
+ * @param `T` : Props를 사용할 컴포넌트 타입
+ * @param [`Props`] : 컴포넌트 커스텀 Props
+ * @param [`A`] : 추가적으로 렌더링 될 수 있는 컴포넌트 타입 (TS 자동완성을 위해 사용)
+ */
+export type PolymorphicPropsWithInnerRefType<
+  T extends React.ElementType,
+  Props = object,
+  AlternateAs extends React.ElementType = T
+> = AsPropsType<T, AlternateAs> &
+  InnerRefType<T> &
   Props &
   Omit<React.ComponentPropsWithoutRef<T>, keyof Props>;
-
-export type PolymorphicPropsTypeWithInnerRef<
-  T extends React.ElementType,
-  Props = object
-> = PolymorphicPropsType<T, Props> & InnerRefType<T>;

--- a/src/customTypes/polymorphicType.ts
+++ b/src/customTypes/polymorphicType.ts
@@ -12,7 +12,7 @@
  * AsPropsType<'div', 'a' | 'button'>
  */
 type AsPropsType<T extends React.ElementType, A extends React.ElementType = T> = {
-  /** 렌더링할 태그 타입 */
+  /** 렌더링할 태그 속성 */
   renderAs?: T | A;
 };
 
@@ -26,7 +26,11 @@ type AsPropsType<T extends React.ElementType, A extends React.ElementType = T> =
  * InnreRefType<'div'>
  */
 type InnerRefType<T extends React.ElementType> = {
-  /** ref를 대체하는 타입 Type */
+  /**
+   * ref를 대체하는 속성
+   *
+   * @type React.ComponentPropsWithRef<T>["ref"]
+   * */
   innerRef?: React.ComponentPropsWithRef<T>["ref"];
 };
 

--- a/src/customTypes/tailwindFormatType.ts
+++ b/src/customTypes/tailwindFormatType.ts
@@ -2,10 +2,6 @@
  * tailwind width 클래스 구분용 타입
  *
  * string이 단순히 w-로 시작하는지 체크
- *
- * @example
- * w-auto, w-full, w-[123rem] -> ok
- * ws-auto, h-full, wisdom-hello -> error
  */
 export type TailwindWidthClassType = `w-${string}`;
 
@@ -13,9 +9,12 @@ export type TailwindWidthClassType = `w-${string}`;
  * tailwind height 클래스 구분용 타입
  *
  * string이 단순히 h-로 시작하는지 체크
- *
- * @example
- * h-auto, h-full, h-[123rem] -> ok
- * hs-auto, w-full, hello-wisdom -> error
  */
 export type TailwindHeightClassType = `h-${string}`;
+
+/**
+ * tailwind max height 클래스 구분용 타입
+ *
+ * string이 단순히 max-h-로 시작하는지 체크
+ */
+export type TailwindMaxHeightClassType = `max-h-${string}`;

--- a/src/customTypes/utilType.ts
+++ b/src/customTypes/utilType.ts
@@ -1,3 +1,12 @@
-export type NonNullableProps<Props> = {
-  [P in keyof Props]: NonNullable<Props[P]>;
+import { VariantProps } from "class-variance-authority";
+
+/** 객체 속성의 값들에서 Nullable한 값 제거하는 타입 */
+export type NonNullableProps<Obj> = {
+  [P in keyof Obj]: NonNullable<Obj[P]>;
 };
+
+/** VariantsProps의 속성의 값들에서 Nullable한 값 제거한 타입 */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type VariantPropsType<Component extends (...args: any) => any> = NonNullableProps<
+  VariantProps<Component>
+>;


### PR DESCRIPTION
## PR 종류

어떤 타입의 Pull Request인가요?

- [ ] 버그 픽스
- [ ] 기능 추가
- [ ] CSS 변경
- [ ] 코드 스타일 변경(포맷팅, 지역 변수 등)
- [x] 리팩토링(기능 변경 X, API 변경 X)
- [ ] 환경 설정 관련 변경
- [ ] 문서 수정
- [ ] 기타... : 설명해주세요.

## 현재는 어떻게 동작하나요?

다형성 컴포넌트에서 As가 제한되어있지 않습니다.

이슈 번호: close #112 

## PR이 적용된다면 어떻게 동작하나요?

- 다형성 컴포넌트 리팩토링 
  : 이제 다형성 컴포넌트의 As를 제한할 수 있습니다.
- createBox 함수 추가
  : createBox 함수를 사용하여 T 타입을 가지면서 defaultAs로 렌더링 되는 Box 컴포넌트를 불러올 수 있습니다.
- Storybook에서 argsType 불러오지 못하는 에러 수정